### PR TITLE
add conformance test fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.3.0
+-----
+
+Switched to make use of the official conformance test fixtures that are provided
+by the maintainers of the xAPI spec.
+
 0.2.0
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "php-xapi/model": "^0.2.0"
+        "php-xapi/model": "^0.4.0",
+        "ramsey/uuid": "~2.9"
     },
     "conflict": {
         "xabbuh/xapi-data-fixtures": "*"
@@ -25,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.2.x-dev"
+            "dev-master": "0.3.x-dev"
         }
     }
 }

--- a/src/AccountFixtures.php
+++ b/src/AccountFixtures.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the xAPI package.
+ *
+ * (c) Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xabbuh\XApi\DataFixtures;
+
+use Xabbuh\XApi\Model\Account;
+
+/**
+ * xAPI account fixtures.
+ *
+ * These fixtures are borrowed from the
+ * {@link https://github.com/adlnet/xAPI_LRS_Test Experience API Learning Record Store Conformance Test} package.
+ */
+class AccountFixtures
+{
+    public static function getTypicalAccount()
+    {
+        return new Account('test', 'https://tincanapi.com');
+    }
+
+    public static function getConsumerAccount()
+    {
+        return new Account('oauth_consumer_x75db', 'https://tincanapi.com/OAuth/Token');
+    }
+}

--- a/src/ActivityFixtures.php
+++ b/src/ActivityFixtures.php
@@ -12,32 +12,32 @@
 namespace Xabbuh\XApi\DataFixtures;
 
 use Xabbuh\XApi\Model\Activity;
-use Xabbuh\XApi\Model\Definition;
 
 /**
- * Activity fixtures.
+ * xAPI statement activity fixtures.
  *
- * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ * These fixtures are borrowed from the
+ * {@link https://github.com/adlnet/xAPI_LRS_Test Experience API Learning Record Store Conformance Test} package.
  */
 class ActivityFixtures
 {
-    /**
-     * Loads an activity.
-     *
-     * @return Activity
-     */
-    public static function getActivity()
+    public static function getTypicalActivity()
     {
-        $description = array(
-            'en-GB' => 'An example of an activity',
-            'en-US' => 'An example of an activity',
-        );
-        $name = array(
-            'en-GB' => 'example activity',
-            'en-US' => 'example activity',
-        );
-        $definition = new Definition($name, $description, 'http://www.example.co.uk/types/exampleactivitytype');
+        return new Activity('http://tincanapi.com/conformancetest/activityid');
+    }
 
-        return new Activity('http://www.example.co.uk/exampleactivity', $definition);
+    public static function getIdActivity()
+    {
+        return new Activity('http://tincanapi.com/conformancetest/activityid');
+    }
+
+    public static function getIdAndDefinitionActivity()
+    {
+        return new Activity('http://tincanapi.com/conformancetest/activityid', DefinitionFixtures::getTypicalDefinition());
+    }
+
+    public static function getAllPropertiesActivity()
+    {
+        return new Activity('http://tincanapi.com/conformancetest/activityid', DefinitionFixtures::getTypicalDefinition());
     }
 }

--- a/src/ActorFixtures.php
+++ b/src/ActorFixtures.php
@@ -17,65 +17,130 @@ use Xabbuh\XApi\Model\Group;
 use Xabbuh\XApi\Model\InverseFunctionalIdentifier;
 
 /**
- * Actor fixtures.
+ * xAPI actor fixtures.
  *
- * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ * These fixtures are borrowed from the
+ * {@link https://github.com/adlnet/xAPI_LRS_Test Experience API Learning Record Store Conformance Test} package.
  */
 class ActorFixtures
 {
-    /**
-     * Loads an agent.
-     *
-     * @return Agent
-     */
-    public static function getAgent()
+    public static function getTypicalAgent()
     {
-        $agent = new Agent(InverseFunctionalIdentifier::withMbox('mailto:christian@example.com'), 'Christian');
-
-        return $agent;
+        return new Agent(InverseFunctionalIdentifier::withMbox('mailto:conformancetest@tincanapi.com'));
     }
 
-    /**
-     * Loads a group.
-     *
-     * @return Group
-     */
-    public static function getGroup()
+    public static function getMboxAgent()
     {
-        $account = new Account('GroupAccount', 'http://example.com/homePage');
-
-        return static::createGroup('Example Group', $account);
+        return new Agent(InverseFunctionalIdentifier::withMbox('mailto:conformancetest@tincanapi.com'));
     }
 
-    /**
-     * Loads a group that has no members.
-     *
-     * @return Group
-     */
-    public static function getGroupWithoutMembers()
+    public static function getMboxSha1SumAgent()
     {
-        $account = new Account('GroupAccount', 'http://example.com/homePage');
-
-        return new Group(InverseFunctionalIdentifier::withAccount($account), 'Example Group');
+        return new Agent(InverseFunctionalIdentifier::withMboxSha1Sum('db77b9104b531ecbb0b967f6942549d0ba80fda1'));
     }
 
-    /**
-     * Loads an anonymous group.
-     *
-     * @return Group
-     */
-    public static function getAnonymousGroup()
+    public static function getOpenIdAgent()
     {
-        return static::createGroup('Anonymous Group');
+        return new Agent(InverseFunctionalIdentifier::withOpenId('http://openid.tincanapi.com'));
     }
 
-    private static function createGroup($name, Account $account = null)
+    public static function getAccountAgent()
     {
-        $memberAccount = new Account('Member of a group', 'http://example.com/account');
-        $agent1 = new Agent(InverseFunctionalIdentifier::withAccount($memberAccount), 'Andrew Downes');
-        $agent2 = new Agent(InverseFunctionalIdentifier::withOpenId('aaron.openid.example.org'), 'Aaron Silvers');
-        $group = new Group(null !== $account ? InverseFunctionalIdentifier::withAccount($account) : null, $name, array($agent1, $agent2));
+        return new Agent(InverseFunctionalIdentifier::withAccount(AccountFixtures::getTypicalAccount()));
+    }
 
-        return $group;
+    public static function getTypicalGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withMbox('mailto:conformancetest-group@tincanapi.com'));
+    }
+
+    public static function getMboxGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withMbox('mailto:conformancetest-group@tincanapi.com'));
+    }
+
+    public static function getMboxSha1SumGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withMboxSha1Sum('4e271041e78101311fb37284ef1a1d35c3f1db35'));
+    }
+
+    public static function getOpenIdGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withOpenId('http://group.openid.tincanapi.com'));
+    }
+
+    public static function getAccountGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withAccount(AccountFixtures::getTypicalAccount()));
+    }
+
+    public static function getMboxAndNameGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withMbox('mailto:conformancetest-group@tincanapi.com'), 'test group');
+    }
+
+    public static function getMboxSha1SumAndNameGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withMboxSha1Sum('4e271041e78101311fb37284ef1a1d35c3f1db35'), 'test group');
+    }
+
+    public static function getOpenIdAndNameGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withOpenId('http://group.openid.tincanapi.com'), 'test group');
+    }
+
+    public static function getAccountAndNameGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withAccount(AccountFixtures::getTypicalAccount()), 'test group');
+    }
+
+    public static function getMboxAndMemberGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withMbox('mailto:conformancetest-group@tincanapi.com'), null, array(self::getTypicalAgent()));
+    }
+
+    public static function getMboxSha1SumAndMemberGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withMboxSha1Sum('4e271041e78101311fb37284ef1a1d35c3f1db35'), null, array(self::getTypicalAgent()));
+    }
+
+    public static function getOpenIdAndMemberGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withOpenId('http://group.openid.tincanapi.com'), null, array(self::getTypicalAgent()));
+    }
+
+    public static function getAccountAndMemberGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withAccount(AccountFixtures::getTypicalAccount()), null, array(self::getTypicalAgent()));
+    }
+
+    public static function getAllPropertiesAndTypicalAgentMemberGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withMbox('mailto:conformancetest-group@tincanapi.com'), 'test group', array(self::getTypicalAgent()));
+    }
+
+    public static function getAllPropertiesAndMboxAgentMemberGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withMbox('mailto:conformancetest-group@tincanapi.com'), 'test group', array(self::getMboxAgent()));
+    }
+
+    public static function getAllPropertiesAndMboxSha1SumAgentMemberGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withMbox('mailto:conformancetest-group@tincanapi.com'), 'test group', array(self::getMboxSha1SumAgent()));
+    }
+
+    public static function getAllPropertiesAndOpenIdAgentMemberGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withMbox('mailto:conformancetest-group@tincanapi.com'), 'test group', array(self::getOpenIdAgent()));
+    }
+
+    public static function getAllPropertiesAndAccountAgentMemberGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withMbox('mailto:conformancetest-group@tincanapi.com'), 'test group', array(self::getAccountAgent()));
+    }
+
+    public static function getAllPropertiesAndTwoTypicalAgentMembersGroup()
+    {
+        return new Group(InverseFunctionalIdentifier::withMbox('mailto:conformancetest-group@tincanapi.com'), 'test group', array(self::getTypicalAgent(), self::getTypicalAgent()));
     }
 }

--- a/src/DefinitionFixtures.php
+++ b/src/DefinitionFixtures.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the xAPI package.
+ *
+ * (c) Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xabbuh\XApi\DataFixtures;
+
+use Xabbuh\XApi\Model\Definition;
+
+/**
+ * xAPI activity definition fixtures.
+ *
+ * These fixtures are borrowed from the
+ * {@link https://github.com/adlnet/xAPI_LRS_Test Experience API Learning Record Store Conformance Test} package.
+ */
+class DefinitionFixtures
+{
+    public static function getEmptyDefinition()
+    {
+        return new Definition();
+    }
+
+    public static function getTypicalDefinition()
+    {
+        return new Definition();
+    }
+
+    public static function getNameDefinition()
+    {
+        return new Definition(array('en-US' => 'test'));
+    }
+
+    public static function getDescriptionDefinition()
+    {
+        return new Definition(null, array('en-US' => 'test'));
+    }
+
+    public static function getTypeDefinition()
+    {
+        return new Definition(null, null, 'http://id.tincanapi.com/activitytype/unit-test');
+    }
+
+    public static function getMoreInfoDefinition()
+    {
+        return new Definition(null, null, null, 'https://github.com/adlnet/xAPI_LRS_Test');
+    }
+
+    public static function getAllPropertiesDefinition()
+    {
+        return new Definition(
+            array('en-US' => 'test'),
+            array('en-US' => 'test'),
+            'http://id.tincanapi.com/activitytype/unit-test',
+            'https://github.com/adlnet/xAPI_LRS_Test'
+        );
+    }
+}

--- a/src/ResultFixtures.php
+++ b/src/ResultFixtures.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the xAPI package.
+ *
+ * (c) Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xabbuh\XApi\DataFixtures;
+
+use Xabbuh\XApi\Model\Result;
+
+/**
+ * xAPI result fixtures.
+ *
+ * These fixtures are borrowed from the
+ * {@link https://github.com/adlnet/xAPI_LRS_Test Experience API Learning Record Store Conformance Test} package.
+ */
+class ResultFixtures
+{
+    public static function getScoreResult()
+    {
+        return new Result(ScoreFixtures::getTypicalScore());
+    }
+
+    public static function getEmptyScoreResult()
+    {
+        return new Result(ScoreFixtures::getEmptyScore());
+    }
+
+    public static function getSuccessResult()
+    {
+        return new Result(null, true);
+    }
+
+    public static function getCompletionResult()
+    {
+        return new Result(null, null, true);
+    }
+
+    public static function getResponseResult()
+    {
+        return new Result(null, null, null, 'test');
+    }
+
+    public static function getDurationResult()
+    {
+        return new Result(null, null, null, null, 'PT2H');
+    }
+
+    public static function getScoreAndSuccessResult()
+    {
+        return new Result(ScoreFixtures::getTypicalScore(), true);
+    }
+
+    public static function getScoreAndCompletionResult()
+    {
+        return new Result(ScoreFixtures::getTypicalScore(), null, true);
+    }
+
+    public static function getScoreAndResponseResult()
+    {
+        return new Result(ScoreFixtures::getTypicalScore(), null, null, 'test');
+    }
+
+    public static function getScoreAndDurationResult()
+    {
+        return new Result(ScoreFixtures::getTypicalScore(), null, null, null, 'PT2H');
+    }
+}

--- a/src/ScoreFixtures.php
+++ b/src/ScoreFixtures.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the xAPI package.
+ *
+ * (c) Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xabbuh\XApi\DataFixtures;
+
+use Xabbuh\XApi\Model\Score;
+
+/**
+ * xAPI score fixtures.
+ *
+ * These fixtures are borrowed from the
+ * {@link https://github.com/adlnet/xAPI_LRS_Test Experience API Learning Record Store Conformance Test} package.
+ */
+class ScoreFixtures
+{
+    public static function getEmptyScore()
+    {
+        return new Score();
+    }
+
+    public static function getTypicalScore()
+    {
+        return new Score(1);
+    }
+
+    public static function getScaledScore()
+    {
+        return new Score(1);
+    }
+
+    public static function getRawScore()
+    {
+        return new Score(null, 100);
+    }
+
+    public static function getMinScore()
+    {
+        return new Score(null, null, 0);
+    }
+
+    public static function getMaxScore()
+    {
+        return new Score(null, null, null, 100);
+    }
+
+    public static function getScaledAndRawScore()
+    {
+        return new Score(1, 100);
+    }
+
+    public static function getScaledAndMinScore()
+    {
+        return new Score(1, null, 0);
+    }
+
+    public static function getScaledAndMaxScore()
+    {
+        return new Score(1, null, null, 100);
+    }
+
+    public static function getRawAndMinScore()
+    {
+        return new Score(null, 100, 0);
+    }
+
+    public static function getRawAndMaxScore()
+    {
+        return new Score(null, 100, null, 100);
+    }
+
+    public static function getMinAndMaxScore()
+    {
+        return new Score(null, null, 0, 100);
+    }
+
+    public static function getScaledRawAndMinScore()
+    {
+        return new Score(1, 100, 0);
+    }
+
+    public static function getScaledRawAndMaxScore()
+    {
+        return new Score(1, 100, null, 100);
+    }
+
+    public static function getRawMinAndMaxScore()
+    {
+        return new Score(null, 100, 0, 100);
+    }
+
+    public static function getAllPropertiesScore()
+    {
+        return new Score(1, 100, 0, 100);
+    }
+}

--- a/src/StatementFixtures.php
+++ b/src/StatementFixtures.php
@@ -11,42 +11,38 @@
 
 namespace Xabbuh\XApi\DataFixtures;
 
-use Xabbuh\XApi\Model\Account;
 use Xabbuh\XApi\Model\Agent;
 use Xabbuh\XApi\Model\Activity;
 use Xabbuh\XApi\Model\Definition;
-use Xabbuh\XApi\Model\Group;
 use Xabbuh\XApi\Model\InverseFunctionalIdentifier;
-use Xabbuh\XApi\Model\Result;
-use Xabbuh\XApi\Model\Score;
 use Xabbuh\XApi\Model\Statement;
 use Xabbuh\XApi\Model\StatementReference;
 use Xabbuh\XApi\Model\SubStatement;
 use Xabbuh\XApi\Model\Verb;
 
 /**
- * Statement fixtures.
+ * xAPI statement fixtures.
  *
- * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ * These fixtures are borrowed from the
+ * {@link https://github.com/adlnet/xAPI_LRS_Test Experience API Learning Record Store Conformance Test} package.
  */
 class StatementFixtures
 {
     const DEFAULT_STATEMENT_ID = '12345678-1234-5678-8234-567812345678';
 
-    /**
-     * Loads a minimal valid statement.
-     *
-     * @param string $id The id of the new Statement
-     *
-     * @return Statement
-     */
     public static function getMinimalStatement($id = self::DEFAULT_STATEMENT_ID)
     {
-        $actor = new Agent(InverseFunctionalIdentifier::withMbox('mailto:xapi@adlnet.gov'));
-        $verb = new Verb('http://adlnet.gov/expapi/verbs/created', array('en-US' => 'created'));
-        $activity = new Activity('http://example.adlnet.gov/xapi/example/activity');
+        return new Statement($id, ActorFixtures::getTypicalAgent(), VerbFixtures::getTypicalVerb(), ActivityFixtures::getTypicalActivity());
+    }
 
-        return new Statement($id, $actor, $verb, $activity);
+    public static function getTypicalStatement()
+    {
+        return new Statement(UuidFixtures::getUniqueUuid(), ActorFixtures::getTypicalAgent(), VerbFixtures::getTypicalVerb(), ActivityFixtures::getTypicalActivity());
+    }
+
+    public static function getVoidingStatement($voidedStatementId = 'e05aa883-acaf-40ad-bf54-02c8ce485fb0')
+    {
+        return new Statement(UuidFixtures::getUniqueUuid(), ActorFixtures::getTypicalAgent(), VerbFixtures::getVoidingVerb(), new StatementReference($voidedStatementId));
     }
 
     /**
@@ -58,9 +54,9 @@ class StatementFixtures
      */
     public static function getStatementWithGroupActor($id = self::DEFAULT_STATEMENT_ID)
     {
-        $group = ActorFixtures::getGroup();
-        $verb = VerbFixtures::getVerb();
-        $activity = ActivityFixtures::getActivity();
+        $group = ActorFixtures::getTypicalGroup();
+        $verb = VerbFixtures::getTypicalVerb();
+        $activity = ActivityFixtures::getTypicalActivity();
 
         return new Statement($id, $group, $verb, $activity);
     }
@@ -74,9 +70,9 @@ class StatementFixtures
      */
     public static function getStatementWithGroupActorWithoutMembers($id = self::DEFAULT_STATEMENT_ID)
     {
-        $group = ActorFixtures::getGroupWithoutMembers();
-        $verb = VerbFixtures::getVerb();
-        $activity = ActivityFixtures::getActivity();
+        $group = ActorFixtures::getTypicalGroup();
+        $verb = VerbFixtures::getTypicalVerb();
+        $activity = ActivityFixtures::getTypicalActivity();
 
         return new Statement($id, $group, $verb, $activity);
     }
@@ -109,13 +105,7 @@ class StatementFixtures
      */
     public static function getStatementWithResult($id = self::DEFAULT_STATEMENT_ID)
     {
-        $actor = new Agent(InverseFunctionalIdentifier::withMbox('mailto:xapi@adlnet.gov'));
-        $verb = new Verb('http://adlnet.gov/expapi/verbs/created', array('en-US' => 'created'));
-        $activity = new Activity('http://example.adlnet.gov/xapi/example/activity');
-        $score = new Score(0.95, 31, 0, 50);
-        $result = new Result($score, true, true, 'Wow, nice work!', 'PT1H0M0S');
-
-        return new Statement($id, $actor, $verb, $activity, $result);
+        return new Statement($id, ActorFixtures::getTypicalAgent(), VerbFixtures::getTypicalVerb(), ActivityFixtures::getTypicalActivity(), ResultFixtures::getScoreAndDurationResult());
     }
 
     /**
@@ -152,12 +142,7 @@ class StatementFixtures
      */
     public static function getStatementWithAgentAuthority($id = self::DEFAULT_STATEMENT_ID)
     {
-        $actor = new Agent(InverseFunctionalIdentifier::withMbox('mailto:xapi@adlnet.gov'));
-        $verb = new Verb('http://adlnet.gov/expapi/verbs/created', array('en-US' => 'created'));
-        $activity = new Activity('http://example.adlnet.gov/xapi/example/activity');
-        $authority = new Agent(InverseFunctionalIdentifier::withAccount(new Account('anonymous', 'http://cloud.scorm.com/')));
-
-        return new Statement($id, $actor, $verb, $activity, null, $authority);
+        return new Statement($id, ActorFixtures::getTypicalAgent(), VerbFixtures::getTypicalVerb(), ActivityFixtures::getTypicalActivity(), null, ActorFixtures::getAccountAgent());
     }
 
     /**
@@ -169,29 +154,17 @@ class StatementFixtures
      */
     public static function getStatementWithGroupAuthority($id = self::DEFAULT_STATEMENT_ID)
     {
-        $actor = new Agent(InverseFunctionalIdentifier::withMbox('mailto:xapi@adlnet.gov'));
-        $verb = new Verb('http://adlnet.gov/expapi/verbs/created', array('en-US' => 'created'));
-        $activity = new Activity('http://example.adlnet.gov/xapi/example/activity');
-        $user = new Agent(InverseFunctionalIdentifier::withAccount(new Account('oauth_consumer_x75db', 'http://example.com/xAPI/OAuth/Token')));
-        $application = new Agent(InverseFunctionalIdentifier::withMbox('mailto:bob@example.com'));
-        $authority = new Group(null, null, array($user, $application));
-
-        return new Statement($id, $actor, $verb, $activity, null, $authority);
+        return new Statement($id, ActorFixtures::getTypicalAgent(), VerbFixtures::getTypicalVerb(), ActivityFixtures::getTypicalActivity(), null, ActorFixtures::getTypicalGroup());
     }
 
     /**
-     * Loads a void statement.
-     *
-     * @param string $id The id of the new Statement
-     *
-     * @return Statement
+     * @return Statement[]
      */
-    public static function getVoidStatement($id = self::DEFAULT_STATEMENT_ID)
+    public static function getStatementCollection()
     {
-        $actor = new Agent(InverseFunctionalIdentifier::withMbox('mailto:xapi@adlnet.gov'));
-        $verb = Verb::createVoidVerb();
-        $object = new StatementReference('e05aa883-acaf-40ad-bf54-02c8ce485fb0');
-
-        return new Statement($id, $actor, $verb, $object);
+        return array(
+            self::getMinimalStatement('12345678-1234-5678-8234-567812345678'),
+            self::getMinimalStatement('12345678-1234-5678-8234-567812345679'),
+        );
     }
 }

--- a/src/StatementReferenceFixtures.php
+++ b/src/StatementReferenceFixtures.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the xAPI package.
+ *
+ * (c) Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xabbuh\XApi\DataFixtures;
+
+use Xabbuh\XApi\Model\StatementReference;
+
+/**
+ * xAPI statement reference fixtures.
+ *
+ * These fixtures are borrowed from the
+ * {@link https://github.com/adlnet/xAPI_LRS_Test Experience API Learning Record Store Conformance Test} package.
+ */
+class StatementReferenceFixtures
+{
+    public static function getTypicalStatementReference()
+    {
+        return new StatementReference('16fd2706-8baf-433b-82eb-8c7fada847da');
+    }
+
+    public static function getAllPropertiesStatementReference()
+    {
+        return new StatementReference('16fd2706-8baf-433b-82eb-8c7fada847da');
+    }
+}

--- a/src/SubStatementFixtures.php
+++ b/src/SubStatementFixtures.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the xAPI package.
+ *
+ * (c) Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xabbuh\XApi\DataFixtures;
+
+use Xabbuh\XApi\Model\SubStatement;
+
+/**
+ * xAPI sub statement fixtures.
+ *
+ * These fixtures are borrowed from the
+ * {@link https://github.com/adlnet/xAPI_LRS_Test Experience API Learning Record Store Conformance Test} package.
+ */
+class SubStatementFixtures
+{
+    public static function getTypicalSubStatement()
+    {
+        return new SubStatement(null, ActorFixtures::getTypicalAgent(), VerbFixtures::getTypicalVerb(), ActivityFixtures::getTypicalActivity());
+    }
+
+    public static function getSubStatementWithMboxAgent()
+    {
+        return new SubStatement(null, ActorFixtures::getMboxAgent(), VerbFixtures::getTypicalVerb(), ActivityFixtures::getTypicalActivity());
+    }
+
+    public static function getSubStatementWithMboxSha1SumAgent()
+    {
+        return new SubStatement(null, ActorFixtures::getMboxSha1SumAgent(), VerbFixtures::getTypicalVerb(), ActivityFixtures::getTypicalActivity());
+    }
+
+    public static function getSubStatementWithOpenIdAgent()
+    {
+        return new SubStatement(null, ActorFixtures::getOpenIdAgent(), VerbFixtures::getTypicalVerb(), ActivityFixtures::getTypicalActivity());
+    }
+
+    public static function getSubStatementWithAccountAgent()
+    {
+        return new SubStatement(null, ActorFixtures::getAccountAgent(), VerbFixtures::getTypicalVerb(), ActivityFixtures::getTypicalActivity());
+    }
+
+    public static function getSubStatementWithMboxGroup()
+    {
+        return new SubStatement(null, ActorFixtures::getMboxGroup(), VerbFixtures::getTypicalVerb(), ActivityFixtures::getTypicalActivity());
+    }
+
+    public static function getSubStatementWithMboxSha1SumGroup()
+    {
+        return new SubStatement(null, ActorFixtures::getMboxSha1SumGroup(), VerbFixtures::getTypicalVerb(), ActivityFixtures::getTypicalActivity());
+    }
+
+    public static function getSubStatementWithOpenIdGroup()
+    {
+        return new SubStatement(null, ActorFixtures::getOpenIdGroup(), VerbFixtures::getTypicalVerb(), ActivityFixtures::getTypicalActivity());
+    }
+
+    public static function getSubStatementWithAccountGroup()
+    {
+        return new SubStatement(null, ActorFixtures::getAccountGroup(), VerbFixtures::getTypicalVerb(), ActivityFixtures::getTypicalActivity());
+    }
+
+    public static function getSubStatementWithIdOnlyVerb()
+    {
+        return new SubStatement(null, ActorFixtures::getTypicalAgent(), VerbFixtures::getIdVerb(), ActivityFixtures::getTypicalActivity());
+    }
+
+    public static function getSubStatementWithMboxAgentObject()
+    {
+        return new SubStatement(null, ActorFixtures::getTypicalAgent(), VerbFixtures::getTypicalVerb(), ActorFixtures::getMboxAgent());
+    }
+
+    public static function getSubStatementWithMboxSha1SumAgentObject()
+    {
+        return new SubStatement(null, ActorFixtures::getTypicalAgent(), VerbFixtures::getTypicalVerb(), ActorFixtures::getMboxSha1SumAgent());
+    }
+
+    public static function getSubStatementWithOpenIdAgentObject()
+    {
+        return new SubStatement(null, ActorFixtures::getTypicalAgent(), VerbFixtures::getTypicalVerb(), ActorFixtures::getOpenIdAgent());
+    }
+
+    public static function getSubStatementWithAccountAgentObject()
+    {
+        return new SubStatement(null, ActorFixtures::getTypicalAgent(), VerbFixtures::getTypicalVerb(), ActorFixtures::getAccountAgent());
+    }
+
+    public static function getSubStatementWithMboxGroupObject()
+    {
+        return new SubStatement(null, ActorFixtures::getTypicalAgent(), VerbFixtures::getTypicalVerb(), ActorFixtures::getMboxGroup());
+    }
+
+    public static function getSubStatementWithMboxSha1SumGroupObject()
+    {
+        return new SubStatement(null, ActorFixtures::getTypicalAgent(), VerbFixtures::getTypicalVerb(), ActorFixtures::getMboxSha1SumGroup());
+    }
+
+    public static function getSubStatementWithOpenIdGroupObject()
+    {
+        return new SubStatement(null, ActorFixtures::getTypicalAgent(), VerbFixtures::getTypicalVerb(), ActorFixtures::getOpenIdGroup());
+    }
+
+    public static function getSubStatementWithAccountGroupObject()
+    {
+        return new SubStatement(null, ActorFixtures::getTypicalAgent(), VerbFixtures::getTypicalVerb(), ActorFixtures::getAccountGroup());
+    }
+
+    public static function getSubStatementWithAllPropertiesAndTypicalAgentMemberGroupObject()
+    {
+        return new SubStatement(null, ActorFixtures::getTypicalAgent(), VerbFixtures::getTypicalVerb(), ActorFixtures::getAllPropertiesAndTypicalAgentMemberGroup());
+    }
+
+    public static function getSubStatementWithAllPropertiesActivityObject()
+    {
+        return new SubStatement(null, ActorFixtures::getTypicalAgent(), VerbFixtures::getTypicalVerb(), ActivityFixtures::getAllPropertiesActivity());
+    }
+
+    public static function getSubStatementWithTypicalStatementReferenceObject()
+    {
+        return new SubStatement(null, ActorFixtures::getTypicalAgent(), VerbFixtures::getTypicalVerb(), StatementReferenceFixtures::getTypicalStatementReference());
+    }
+}

--- a/src/UuidFixtures.php
+++ b/src/UuidFixtures.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * xAPI statement activity fixtures.
+ *
+ * These fixtures are borrowed from the
+ * {@link https://github.com/adlnet/xAPI_LRS_Test Experience API Learning Record Store Conformance Test} package.
+ */
+
+namespace Xabbuh\XApi\DataFixtures;
+
+use Rhumsaa\Uuid\Uuid;
+
+/**
+ * xAPI UUID fixtures.
+ *
+ * These fixtures are borrowed from the
+ * {@link https://github.com/adlnet/xAPI_LRS_Test Experience API Learning Record Store Conformance Test} package.
+ */
+class UuidFixtures
+{
+    public static function getGoodUuid()
+    {
+        return '39e24cc4-69af-4b01-a824-1fdc6ea8a3af';
+    }
+
+    public static function getBadUuid()
+    {
+        return 'bad-uuid';
+    }
+
+    public static function getUniqueUuid()
+    {
+        return (string) Uuid::uuid4();
+    }
+}

--- a/src/VerbFixtures.php
+++ b/src/VerbFixtures.php
@@ -14,25 +14,30 @@ namespace Xabbuh\XApi\DataFixtures;
 use Xabbuh\XApi\Model\Verb;
 
 /**
- * {@link Verb} fixtures
+ * xAPI verb fixtures.
  *
- * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ * These fixtures are borrowed from the
+ * {@link https://github.com/adlnet/xAPI_LRS_Test Experience API Learning Record Store Conformance Test} package.
  */
 class VerbFixtures
 {
-    public static function getVerb()
+    public static function getTypicalVerb()
     {
-        return new Verb('http://adlnet.gov/expapi/verbs/created', array(
-            'en-US' => 'created',
-        ));
+        return new Verb('http://tincanapi.com/conformancetest/verbid', array('en-US' => 'test'));
     }
 
-    public static function getTravelledVerb()
+    public static function getVoidingVerb()
     {
-        return new Verb('http://www.adlnet.gov/XAPIprofile/ran(travelled_a_distance)', array(
-            'en-US' => 'ran',
-            'es' => 'corrió',
-            'de' => 'rannte',
-        ));
+        return new Verb('http://adlnet.gov/expapi/verbs/voided', array('en-US' => 'voided'));
+    }
+
+    public static function getIdVerb()
+    {
+        return new Verb('http://tincanapi.com/conformancetest/verbid');
+    }
+
+    public static function getIdAndDisplayVerb()
+    {
+        return new Verb('http://tincanapi.com/conformancetest/verbid', array('en-US' => 'test'));
     }
 }

--- a/validate.php
+++ b/validate.php
@@ -2,10 +2,39 @@
 
 include __DIR__.'/vendor/autoload.php';
 
-foreach (glob(__DIR__.'/src/*.php') as $file) {
-    $className = 'Xabbuh\XApi\DataFixtures\\'.substr(basename($file), 0, -4);
+$status = 0;
+$typeMap = array(
+    'Xabbuh\XApi\DataFixtures\StatementFixtures::getStatementCollection' => 'array',
+    'Xabbuh\XApi\DataFixtures\UuidFixtures' => 'string',
+);
 
-    foreach (get_class_methods($className) as $method) {
-        call_user_func(array($className, $method));
+foreach (glob(__DIR__.'/src/*.php') as $path) {
+    $filename = substr(basename($path), 0, -4);
+    $fixturesClassName = 'Xabbuh\XApi\DataFixtures\\'.$filename;
+
+    foreach (get_class_methods($fixturesClassName) as $method) {
+        $object = call_user_func(array($fixturesClassName, $method));
+
+        if (isset($typeMap[$fixturesClassName.'::'.$method])) {
+            $type = $typeMap[$fixturesClassName.'::'.$method];
+        } elseif (isset($typeMap[$fixturesClassName])) {
+            $type = $typeMap[$fixturesClassName];
+        } else {
+            $type = 'object';
+        }
+
+        if (gettype($object) !== $type) {
+            file_put_contents('php://stderr', sprintf(
+                'Expected %s::%s to return data of type "%s", but got "%s"'.PHP_EOL,
+                $filename,
+                $method,
+                $type,
+                gettype($object)
+            ));
+            $status = 1;
+        }
+
     }
 }
+
+exit($status);


### PR DESCRIPTION
This adds all the fixtures that are part of the xAPI conformance test
library (see https://github.com/adlnet/xAPI_LRS_Test).
